### PR TITLE
Fix: Correct spelling of "addTemaMember" to "addTeamMember"

### DIFF
--- a/src/lib/TeamForm.svelte
+++ b/src/lib/TeamForm.svelte
@@ -13,7 +13,7 @@
 
   let email = '';
 
-  const addTemaMember = async (event) => {
+  const addTeamMember = async (event) => {
     try {
       
     } catch (error) {


### PR DESCRIPTION
Corrected the spelling error in the function name from addTemaMember to addTeamMember for  clarity.